### PR TITLE
Remove invalid document tags from chart templates

### DIFF
--- a/ui/solar_line_chart.erb
+++ b/ui/solar_line_chart.erb
@@ -84,8 +84,6 @@
             color: #666;
         }
     </style>
-</head>
-<body>
                 <div class="item">
                     <div class="meta"></div>
                     <div class="content">
@@ -202,5 +200,3 @@
             window.addEventListener("chartkick:load", createChart, true);
         }
     </script>
-</body>
-</html>

--- a/ui/temperature_chart.erb
+++ b/ui/temperature_chart.erb
@@ -89,8 +89,6 @@
     stroke-dasharray: 2,2;
   }
 </style>
-</head>
-<body>
   <div class="view view--full">
 
     <div id="weather-chart" style="width: 100%"></div>


### PR DESCRIPTION
Closes #15

## Summary
- remove stray </head>, <body>, and </html> tags from the chart ERB fragments
- keep the templates as HTML fragments compatible with TRMNL rendering

## Testing
- not run (template-only change)