### PR TITLE
Use configured display timezone in chart templates

### DIFF
--- a/app/plugins/solar_power.py
+++ b/app/plugins/solar_power.py
@@ -91,7 +91,10 @@ from(bucket: "{bucket}")
         formatted_timestamp = local_now.strftime("%A, %B %-d, %-I:%M %p")
 
         # Build result with stringified arrays for each entity
-        result = {"current_timestamp": formatted_timestamp}
+        result = {
+            "current_timestamp": formatted_timestamp,
+            "display_timezone": self.get_timezone(),
+        }
 
         for entity_id, data in sensors_data.items():
             # JavaScript-compatible string representation

--- a/app/plugins/temperature_chart.py
+++ b/app/plugins/temperature_chart.py
@@ -86,6 +86,7 @@ from(bucket: "{bucket}")
 
         return {
             "current_timestamp": formatted_timestamp,
+            "display_timezone": self.get_timezone(),
             f"js_{outdoor_temp_entity}": js_data_str,
         }
 

--- a/ui/solar_line_chart.erb
+++ b/ui/solar_line_chart.erb
@@ -129,7 +129,7 @@
                 xtype: "datetime",
                 library: {
                     time: {
-                        timezone: "America/New_York" // Set timezone here
+                        timezone: "{{display_timezone}}"
                     },
                     chart: {
                         title: {
@@ -178,7 +178,7 @@
                                 color: "#000000"
                             },
                             formatter: function() {
-                                return moment.tz(this.value, "America/New_York").format("HH:mm");
+                                return moment.tz(this.value, "{{display_timezone}}").format("HH:mm");
                             }
                         },
                         lineWidth: 0,

--- a/ui/temperature_chart.erb
+++ b/ui/temperature_chart.erb
@@ -129,7 +129,7 @@
           xtype: "datetime",
           library: {
             time: {
-              timezone: "America/New_York"
+              timezone: "{{display_timezone}}"
             },
             chart: {
               title: {
@@ -193,7 +193,7 @@
                   color: "#000000"
                 },
                 formatter: function() {
-                  return moment.tz(this.value, "America/New_York").format("HH:mm");
+                  return moment.tz(this.value, "{{display_timezone}}").format("HH:mm");
                 }
               },
               lineWidth: 0,


### PR DESCRIPTION
Closes #16

## Summary
- pass the configured display timezone through the solar and temperature chart payloads
- replace hardcoded America/New_York literals in the chart templates

## Testing
- not run (template and payload wiring change)