### PR TITLE
Use stable payload key for temperature chart

### DIFF
--- a/app/plugins/temperature_chart.py
+++ b/app/plugins/temperature_chart.py
@@ -87,7 +87,7 @@ from(bucket: "{bucket}")
         return {
             "current_timestamp": formatted_timestamp,
             "display_timezone": self.get_timezone(),
-            f"js_{outdoor_temp_entity}": js_data_str,
+            "js_temperature_data": js_data_str,
         }
 
     def get_webhook_id(self) -> str:

--- a/ui/temperature_chart.erb
+++ b/ui/temperature_chart.erb
@@ -103,7 +103,7 @@
   </div>
 
   <script type="text/javascript">
-    var data = {{js_evan_s_pws_temperature}};
+    var data = {{js_temperature_data}};
 
     // Find temperature range for better y-axis setup
     const temperatures = data.map(point => point[1]);


### PR DESCRIPTION
Closes #18

## Summary
- rename the temperature chart payload field to a stable js_temperature_data key
- update the ERB template to use the generic field instead of an entity-specific name

## Testing
- not run (payload and template wiring change)