### PR TITLE
Fix freezing plot band lower bound

### DIFF
--- a/ui/temperature_chart.erb
+++ b/ui/temperature_chart.erb
@@ -80,7 +80,7 @@
               gridLineWidth: 1,
               gridLineColor: "#000000",
               plotBands: [{
-                from: null,
+                from: minTemp,
                 to: 32,
                 color: 'rgba(200, 200, 200, 0.5)' // Grey shading below freezing
               }],


### PR DESCRIPTION
Closes #19

## Summary
- use the computed chart minimum as the start of the freezing plot band
- avoid relying on an invalid null lower bound in Highcharts

## Testing
- not run (template-only change)