### PR TITLE
Enable grid power series in solar line chart

### DIFF
--- a/ui/solar_line_chart.erb
+++ b/ui/solar_line_chart.erb
@@ -25,7 +25,7 @@
 
     <script type="text/javascript">
         // Empty data arrays to be filled in later
-        //var gridData = {{str_bellmore_grid_power}};
+        var gridData = {{str_bellmore_grid_power}};
         var loadData = {{str_bellmore_load_power}};
         var solarData = {{str_bellmore_solar_power}};
 
@@ -34,7 +34,7 @@
             new Chartkick["LineChart"](
             "solar-chart",
             [
-                // {name: "Grid Power", data: gridData, dashStyle: "dash"},
+                {name: "Grid Power", data: gridData, dashStyle: "dash"},
                 {name: "House load", data: loadData, dashStyle: "dot"},
                 {name: "Solar Generation", data: solarData, dashStyle: "solid"},
             ],


### PR DESCRIPTION
Closes #20

## Summary
- un-comment the existing grid power series in the solar line chart template
- use the grid data that is already available from the configured solar power plugin payload

## Testing
- not run (template-only change)