### PR TITLE
Add peak solar summary to solar line chart

### DIFF
--- a/app/plugins/solar_power.py
+++ b/app/plugins/solar_power.py
@@ -90,12 +90,24 @@ from(bucket: "{bucket}")
         local_now = datetime.now(timezone.utc).astimezone(local_tz)
         formatted_timestamp = local_now.strftime("%A, %B %-d, %-I:%M %p")
         daily_energy = self._query_daily_energy(entities.get("solar_power"))
+        peak_solar_kw = 0.0
+        peak_solar_time = "N/A"
+        solar_entity_id = entities.get("solar_power")
+        solar_points = sensors_data.get(solar_entity_id, []) if solar_entity_id else []
+        if solar_points:
+            peak_timestamp_ms, peak_solar_kw = max(solar_points, key=lambda point: point[1])
+            peak_local_time = datetime.fromtimestamp(
+                peak_timestamp_ms / 1000, tz=local_tz
+            )
+            peak_solar_time = peak_local_time.strftime("%-I:%M %p")
 
         # Build result with stringified arrays for each entity
         result = {
             "current_timestamp": formatted_timestamp,
             "display_timezone": self.get_timezone(),
             "str_daily_energy": round_value(daily_energy, 1),
+            "peak_solar_kw": round_value(peak_solar_kw, 1),
+            "peak_solar_time": peak_solar_time,
         }
 
         for entity_id, data in sensors_data.items():

--- a/ui/solar_line_chart.erb
+++ b/ui/solar_line_chart.erb
@@ -12,6 +12,14 @@
                     </div>
                 </div>
 
+                <div class="item">
+                    <div class="meta"></div>
+                    <div class="content">
+                        <span class="title title--small">{{peak_solar_kw}} kW @ {{peak_solar_time}}</span>
+                        <span class="description">Peak Solar Today</span>
+                    </div>
+                </div>
+
             <div id="solar-chart" style="width: 100%"></div>
 
         <div class="title_bar">


### PR DESCRIPTION
Closes #24

## Summary
- compute the peak solar output and timestamp from the collected solar series
- display the peak value and time as a compact stat above the solar line chart

## Testing
- python3 -m py_compile app/plugins/solar_power.py