### PR TITLE
Add weekly solar total summary stat

### DIFF
--- a/app/plugins/solar_summary.py
+++ b/app/plugins/solar_summary.py
@@ -153,11 +153,13 @@ from(bucket: "{bucket}")
                     break
 
         # Build merge_variables with JSON stringified arrays
+        weekly_solar_total = round_value(sum(s["solar"] for s in slots), 1)
         merge = {
             "str_categories": json.dumps([s["date"] for s in slots]),
             "str_grid": json.dumps([s["grid"] for s in slots]),
             "str_load": json.dumps([s["load"] for s in slots]),
             "str_solar": json.dumps([s["solar"] for s in slots]),
+            "str_weekly_solar_total": weekly_solar_total,
         }
 
         logger.info(f"Formatted solar summary for {len(slots)} days")

--- a/ui/solar_bar_chart.erb
+++ b/ui/solar_bar_chart.erb
@@ -9,6 +9,10 @@
     <!-- Chart container -->
     <div id="weekly-chart" class="w--full h--400 mt--2"></div>
   </div>
+  <div class="content">
+    <span class="value value--small">Week total: {{str_weekly_solar_total}} kWh</span>
+    <span class="label">Solar generation to date</span>
+  </div>
   <div class="title_bar">
     <img class="image" src="/images/plugins/trmnl--render.svg" />
     <span class="title">Solar Panel Summary</span>


### PR DESCRIPTION
Closes #25

## Summary
- compute the summed solar total from the existing weekly solar summary slots
- render a simple week-total stat above the solar summary chart

## Testing
- python3 -m py_compile app/plugins/solar_summary.py