### PR TITLE
Add SVG sparkline example for issue #51

### DIFF
--- a/docs/sparkline_example.svg
+++ b/docs/sparkline_example.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" width="240" height="48">
+  <!-- Background -->
+  <rect width="240" height="48" fill="white"/>
+
+  <!-- Area fill under line -->
+  <polygon
+    points="0,31 22,36 44,42 66,40 88,31 110,24 132,17 154,10 176,4 198,2 220,4 240,8 240,48 0,48"
+    fill="#000" fill-opacity="0.07"/>
+
+  <!-- Sparkline -->
+  <polyline
+    points="0,31 22,36 44,42 66,40 88,31 110,24 132,17 154,10 176,4 198,2 220,4 240,8"
+    fill="none" stroke="#000" stroke-width="1.8"
+    stroke-linejoin="round" stroke-linecap="round"/>
+
+  <!-- Min/max labels -->
+  <text x="44" y="48" font-family="monospace" font-size="8" fill="#555" text-anchor="middle">30.0°</text>
+  <text x="198" y="11" font-family="monospace" font-size="8" fill="#555" text-anchor="middle">33.2°</text>
+
+  <!-- Dot at latest value -->
+  <circle cx="240" cy="8" r="2.5" fill="#000"/>
+</svg>


### PR DESCRIPTION
Adds a sample SVG sparkline to `docs/` for reference in issue #51.

Closes N/A — supporting asset only.