### PR TITLE
fix TRMNL shading and temperature chart layout

### DIFF
--- a/ui/pws_dashboard.erb
+++ b/ui/pws_dashboard.erb
@@ -2,19 +2,19 @@
 <div class="view view--full">
   <div class="layout layout--col">
     <div class="grid grid--cols-3 gap--small" style="margin-bottom: 8px;">
-      <div class="item bg--gray-15" style="border: 1px solid #d8d8d8;">
+      <div class="item bg--gray-65" style="border: 1px solid #d8d8d8;">
         <div class="content">
           <span class="value value--xsmall">Trend Window</span>
           <span class="label">{{temp_sparkline_start}} to {{temp_sparkline_end}}</span>
         </div>
       </div>
-      <div class="item bg--gray-15" style="border: 1px solid #d8d8d8;">
+      <div class="item bg--gray-65" style="border: 1px solid #d8d8d8;">
         <div class="content">
           <span class="value value--xsmall">Trend Low</span>
           <span class="label">{{temp_sparkline_min}} • {{temp_sparkline_min_time}}</span>
         </div>
       </div>
-      <div class="item bg--gray-15" style="border: 1px solid #d8d8d8;">
+      <div class="item bg--gray-65" style="border: 1px solid #d8d8d8;">
         <div class="content">
           <span class="value value--xsmall">Trend High</span>
           <span class="label">{{temp_sparkline_max}} • {{temp_sparkline_max_time}}</span>
@@ -90,55 +90,55 @@
       </div>
       <div class="col col--span-6 col--end">
         <div class="grid grid--cols-2 gap--medium">
-          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">Pressure {{baromrelin}} inHg</span>
               <span class="label">{{pressure_trend_label}} over 3h</span>
             </div>
           </div>
-          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{wind_compact}}</span>
               <span class="label">{{wind_gust_pretty}}</span>
             </div>
           </div>
-          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{feelsLike | round}}°</span>
               <span class="label">Feels Like</span>
             </div>
           </div>
-          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{humidity}}%</span>
               <span class="label">Humidity</span>
             </div>
           </div>
-          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{dewPoint | round}}°</span>
               <span class="label">Dew Point</span>
             </div>
           </div>
-          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{uv | round}}</span>
               <span class="label">UV Index</span>
             </div>
           </div>
-          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{solarradiation | round}} W/m²</span>
               <span class="label">Solar Radiation</span>
             </div>
           </div>
-          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{dailyrainin | round: 2}} in</span>
               <span class="label">Rain Today</span>
             </div>
           </div>
-          <div class="item bg--gray-15" style="grid-column: span 2; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-65" style="grid-column: span 2; border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{last_rain_date_pretty}}</span>
               <span class="label">Last Rain</span>

--- a/ui/pws_dashboard.erb
+++ b/ui/pws_dashboard.erb
@@ -2,19 +2,19 @@
 <div class="view view--full">
   <div class="layout layout--col">
     <div class="grid grid--cols-3 gap--small" style="margin-bottom: 8px;">
-      <div class="item" style="background-color: #f2f2f2; border: 1px solid #d8d8d8;">
+      <div class="item bg--gray-15" style="border: 1px solid #d8d8d8;">
         <div class="content">
           <span class="value value--xsmall">Trend Window</span>
           <span class="label">{{temp_sparkline_start}} to {{temp_sparkline_end}}</span>
         </div>
       </div>
-      <div class="item" style="background-color: #f2f2f2; border: 1px solid #d8d8d8;">
+      <div class="item bg--gray-15" style="border: 1px solid #d8d8d8;">
         <div class="content">
           <span class="value value--xsmall">Trend Low</span>
           <span class="label">{{temp_sparkline_min}} • {{temp_sparkline_min_time}}</span>
         </div>
       </div>
-      <div class="item" style="background-color: #f2f2f2; border: 1px solid #d8d8d8;">
+      <div class="item bg--gray-15" style="border: 1px solid #d8d8d8;">
         <div class="content">
           <span class="value value--xsmall">Trend High</span>
           <span class="label">{{temp_sparkline_max}} • {{temp_sparkline_max_time}}</span>
@@ -90,55 +90,55 @@
       </div>
       <div class="col col--span-6 col--end">
         <div class="grid grid--cols-2 gap--medium">
-          <div class="item" style="background-color: #f6f6f6; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">Pressure {{baromrelin}} inHg</span>
               <span class="label">{{pressure_trend_label}} over 3h</span>
             </div>
           </div>
-          <div class="item" style="background-color: #efefef; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{wind_compact}}</span>
               <span class="label">{{wind_gust_pretty}}</span>
             </div>
           </div>
-          <div class="item" style="background-color: #f6f6f6; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{feelsLike | round}}°</span>
               <span class="label">Feels Like</span>
             </div>
           </div>
-          <div class="item" style="background-color: #efefef; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{humidity}}%</span>
               <span class="label">Humidity</span>
             </div>
           </div>
-          <div class="item" style="background-color: #f6f6f6; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{dewPoint | round}}°</span>
               <span class="label">Dew Point</span>
             </div>
           </div>
-          <div class="item" style="background-color: #efefef; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{uv | round}}</span>
               <span class="label">UV Index</span>
             </div>
           </div>
-          <div class="item" style="background-color: #f6f6f6; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-10" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{solarradiation | round}} W/m²</span>
               <span class="label">Solar Radiation</span>
             </div>
           </div>
-          <div class="item" style="background-color: #efefef; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-20" style="border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{dailyrainin | round: 2}} in</span>
               <span class="label">Rain Today</span>
             </div>
           </div>
-          <div class="item" style="grid-column: span 2; background-color: #f1f1f1; border: 1px solid #dcdcdc;">
+          <div class="item bg--gray-15" style="grid-column: span 2; border: 1px solid #dcdcdc;">
             <div class="content">
               <span class="value value--xsmall">{{last_rain_date_pretty}}</span>
               <span class="label">Last Rain</span>

--- a/ui/temperature_chart.erb
+++ b/ui/temperature_chart.erb
@@ -28,6 +28,47 @@
     minTemp = Math.floor(minTemp) - 3;
     maxTemp = Math.ceil(maxTemp) + 3;
 
+    function buildFreezingHatchLines(minimumTemp) {
+      if (minimumTemp >= 32) {
+        return [];
+      }
+
+      const lines = [];
+      const startTemp = Math.ceil(minimumTemp);
+
+      // Use explicit horizontal hatch lines because TRMNL's renderer drops plotBand fills.
+      for (let value = startTemp; value < 32; value += 2) {
+        lines.push({
+          value: value,
+          color: value % 4 === 0 ? "#b5b5b5" : "#d4d4d4",
+          width: value % 4 === 0 ? 2 : 1,
+          dashStyle: value % 4 === 0 ? "Solid" : "ShortDot",
+          zIndex: 0
+        });
+      }
+
+      lines.push({
+        value: 32,
+        color: "black",
+        width: 2,
+        dashStyle: "Dash",
+        zIndex: 1,
+        label: {
+          text: "Freezing (32°F)",
+          align: "right",
+          x: -10,
+          style: {
+            color: "black",
+            fontWeight: "bold"
+          }
+        }
+      });
+
+      return lines;
+    }
+
+    const freezingHatchLines = buildFreezingHatchLines(minTemp);
+
     // recommended configs to achieve the e-ink friendly aesthetic
     var createChart = function() {
       new Chartkick["LineChart"](
@@ -85,26 +126,7 @@
               gridLineDashStyle: "shortdot",
               gridLineWidth: 1,
               gridLineColor: "#000000",
-              plotBands: [{
-                from: minTemp,
-                to: 32,
-                color: 'rgba(200, 200, 200, 0.5)' // Grey shading below freezing
-              }],
-              plotLines: [{
-                value: 32,
-                color: 'black',
-                width: 2,
-                dashStyle: 'dash',
-                label: {
-                  text: 'Freezing (32°F)',
-                  align: 'right',
-                  x: -10,
-                  style: {
-                    color: 'black',
-                    fontWeight: 'bold'
-                  }
-                }
-              }]
+              plotLines: freezingHatchLines
             },
             xAxis: {
               type: "datetime",

--- a/ui/temperature_chart.erb
+++ b/ui/temperature_chart.erb
@@ -6,7 +6,7 @@
 
   <div class="view view--full">
 
-    <div id="weather-chart" style="width: 100%"></div>
+    <div id="weather-chart" style="width: 100%; height: 408px;"></div>
 
     <div class="title_bar">
       <img class="image" src="https://cdn-icons-png.flaticon.com/512/16342/16342339.png" />
@@ -33,21 +33,7 @@
         return [];
       }
 
-      const lines = [];
-      const startTemp = Math.ceil(minimumTemp);
-
-      // Use explicit horizontal hatch lines because TRMNL's renderer drops plotBand fills.
-      for (let value = startTemp; value < 32; value += 2) {
-        lines.push({
-          value: value,
-          color: value % 4 === 0 ? "#b5b5b5" : "#d4d4d4",
-          width: value % 4 === 0 ? 2 : 1,
-          dashStyle: value % 4 === 0 ? "Solid" : "ShortDot",
-          zIndex: 0
-        });
-      }
-
-      lines.push({
+      return [{
         value: 32,
         color: "black",
         width: 2,
@@ -62,9 +48,7 @@
             fontWeight: "bold"
           }
         }
-      });
-
-      return lines;
+      }];
     }
 
     const freezingHatchLines = buildFreezingHatchLines(minTemp);
@@ -91,9 +75,13 @@
             },
             chart: {
               title: {
-                text: 'Indoor / Outdoor Temperature'
+                text: null
               },
-              height: 360,
+              height: 408,
+              spacingTop: 6,
+              spacingBottom: 8,
+              spacingLeft: 0,
+              spacingRight: 0,
               style: {
                 fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
               }


### PR DESCRIPTION
## Summary
- switch `pws_dashboard` tiles to TRMNL framework background classes for renderer-safe shading
- simplify the temperature chart freezing marker to a single 32°F line
- increase the chart plot area and remove the redundant internal title

## Testing
- pytest -q